### PR TITLE
Create rm.go

### DIFF
--- a/rm.go
+++ b/rm.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+  "flag"
+  "os"
+  "fmt"
+)
+
+func main() {
+
+  flag.Parse()
+  err := os.Remove(flag.Arg(0))
+
+  if err != nil {
+      fmt.Println(err)
+  }
+}


### PR DESCRIPTION
pass on cygwin with go version go1.4 windows/amd64
rm recursively is not supported yet